### PR TITLE
Label rectangles with letters instead of numbers

### DIFF
--- a/info/task_description.html
+++ b/info/task_description.html
@@ -35,8 +35,8 @@
  [0, 0, 2, 0, 0, 6],           (2, 3, 3, 3), (4, 2, 4, 3),
  [0, 0, 0, 4, 0, 0]]           (5, 2, 5, 5)}&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 
-Rectangle <span style="color: #FA8F00">0</span> starts at (0, 0) and ends at (0, 2).
-Rectangle <span style="color: #FA8F00">1</span> starts at (1, 2) and ends at (3, 2).
+Rectangle <span style="color: #FA8F00">A</span> starts at (0, 0) and ends at (0, 2).
+Rectangle <span style="color: #FA8F00">B</span> starts at (1, 2) and ends at (3, 2).
 ...
 </pre>
 


### PR DESCRIPTION
This is just a suggestion to make the presentation of the problem a little clearer.

I was momentarily confused with the two sets of numbers in the image of the puzzle description. It would be easier to understand if the rectangles were labeled with letters `A-K` instead of numbers `0-10`. However, that requires updating the image /:

[Example](https://imgur.com/9pAQnpt) updated image (of amazing quality :wink: ).

If you don't feel it's worth the effort, I getcha.

Cheers! (cool puzzle, by the way)